### PR TITLE
Update package to work with primer react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@github/frontend-project",
+  "name": "@primer/behaviors",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@github/frontend-project",
+      "name": "@primer/behaviors",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,24 +1,22 @@
 {
   "name": "@primer/behaviors",
-  "private": true,
   "version": "1.0.0",
-  "description": "Template repository making it easier for developers to write frontend functionality that will be integrated into dotcom",
-  "exports": {
-    ".": "./dist/index.js",
-    "./utils": "./dist/utils/index.js"
-  },
+  "description": "Shared behaviors for JavaScript components",
+  "main": "./dist/index.js",
   "type": "module",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "style": "dist/index.css",
-  "assets": [],
+  "sideEffects": [
+    "dist/focus-zone.js",
+    "dist/focus-trap.js"
+  ],
   "scripts": {
     "lint": "eslint src/",
     "test": "npm run jest && npm run lint",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "jest": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "jest --watch",
+    "jest": "jest",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
     "build": "tsc",
@@ -27,19 +25,24 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/github/frontend-project.git"
+    "url": "git+https://github.com/primer/behaviors.git"
   },
-  "keywords": [],
+  "keywords": [
+    "primer",
+    "behavior",
+    "behaviors",
+    "focus"
+  ],
   "author": "",
   "prettier": "@github/prettier-config",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/github/frontend-project/issues"
+    "url": "https://github.com/primer/behaviors/issues"
   },
-  "homepage": "https://github.com/github/frontend-project#readme",
+  "homepage": "https://github.com/primer/behaviors#readme",
   "size-limit": [
     {
-      "limit": "100kb",
+      "limit": "10kb",
       "path": "dist/index.js"
     }
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "ES2020",
-    "target": "es2020",
+    "target": "ES2015",
     "jsx": "react",
     "lib": ["es2020", "dom", "dom.iterable"],
     "strict": true,


### PR DESCRIPTION
After `npm link`ing with PRC, I found a number of tweaks I needed to make.  Also found a bunch of references that needed to be updated before we actually publish this to npm

* Need to set `main` instead of `exports`.  I tried to get fancy with exports so that we could import `@primer/behaviors/utils`, but it didn't work.  For now we can just import `@primer/behaviors/dist/utils` for the one use case we have in PRC.
* The storybook setup in PRC does not do any transpilation on node_modules and was choking on the `??` operators.  I changed the typescript `target` to `es2015` for now so they get transpiled away before we publish