### PR TITLE
Skip changeset check for dependabot

### DIFF
--- a/.github/workflows/check_for_changeset.yml
+++ b/.github/workflows/check_for_changeset.yml
@@ -2,8 +2,6 @@ name: Check for changeset
 
 on:
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
     types:
       # On by default if you specify no types.
       - "opened"
@@ -16,6 +14,7 @@ on:
 jobs:
   check-for-changeset:
     name: Check for changeset
+    if: startsWith(github.head_ref, 'dependabot/') == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`branches-ignore` is based on _target_ branch for PRs, so we can't use it here