### PR TITLE
Fix logic error on docs for focusTrap

### DIFF
--- a/docs/focus-trap.md
+++ b/docs/focus-trap.md
@@ -27,7 +27,7 @@ const dialogController = showDialog()
 
 // later
 if (dialogController) {
-  hideDialog(controller)
+  hideDialog(dialogController)
 }
 ```
 


### PR DESCRIPTION
# Motivation

The abortController variable is called `dialogController` and incorrectly referenced as `controller` later in the example.