### PR TITLE
Export both esm and cjs

### DIFF
--- a/.changeset/eleven-crabs-flow.md
+++ b/.changeset/eleven-crabs-flow.md
@@ -1,0 +1,5 @@
+---
+"@primer/behaviors": patch
+---
+
+Build both esm and cjs output for the package

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,8 @@
  * https://jestjs.io/docs/configuration
  */
 
-// eslint-disable-next-line filenames/match-regex
-export default {
+// eslint-disable-next-line filenames/match-regex,import/no-commonjs,no-undef
+module.exports = {
   clearMocks: true,
   testEnvironment: 'jsdom',
   transform: {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,30 @@
   "name": "@primer/behaviors",
   "version": "1.0.2",
   "description": "Shared behaviors for JavaScript components",
-  "main": "./dist/index.js",
-  "type": "module",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "module": "./dist/esm/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "require": "./dist/cjs/utils/index.js",
+      "module": "./dist/esm/utils/index.js"
+    }
+  },
+  "types": "dist/cjs/index.d.ts",
   "files": [
     "dist",
     "utils"
   ],
   "sideEffects": [
-    "dist/focus-zone.js",
-    "dist/focus-trap.js"
+    "dist/esm/focus-zone.js",
+    "dist/esm/focus-trap.js",
+    "dist/cjs/focus-zone.js",
+    "dist/cjs/focus-trap.js"
   ],
   "scripts": {
     "lint": "eslint src/",
@@ -20,7 +34,9 @@
     "jest": "jest",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "size-limit": "npm run build && size-limit",
     "release": "npm run build && changeset publish"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "size-limit": [
     {
       "limit": "10kb",
-      "path": "dist/index.js"
+      "path": "dist/esm/index.js"
     }
   ],
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["es2020", "dom", "dom.iterable"],
     "strict": true,
     "declaration": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "removeComments": true,
     "preserveConstEnums": true,
     "moduleResolution": "node",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@primer/behaviors/utils",
-  "types": "../dist/utils/index.d.ts",
-  "main": "../dist/utils/index.js",
+  "types": "../dist/esm/utils/index.d.ts",
+  "main": "../dist/esm/utils/index.js",
   "type": "module",
   "sideEffects": false
 }


### PR DESCRIPTION
Alternate approach to #39 using `tsc` instead of `babel`. This allows consumers of the package to use either CommonJS or ESM.