### PR TITLE
Update focusTrap to use new methodology after accessibility discussions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.DS_Store

--- a/src/__tests__/focus-trap.test.tsx
+++ b/src/__tests__/focus-trap.test.tsx
@@ -1,6 +1,7 @@
-import {fireEvent, render} from '@testing-library/react'
 import React from 'react'
 import {focusTrap} from '../focus-trap.js'
+import {render} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 // Since we use strict `isTabbable` checks within focus trap, we need to mock these
 // properties that Jest does not populate.
@@ -22,7 +23,7 @@ beforeAll(() => {
   }
 })
 
-it('Should initially focus the container when activated', () => {
+it('Should initially focus the first element when activated', () => {
   const {container} = render(
     <div>
       <button tabIndex={0}>Bad Apple</button>
@@ -35,8 +36,9 @@ it('Should initially focus the container when activated', () => {
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const firstButton = trapContainer.querySelector('button')!
   const controller = focusTrap(trapContainer)
-  expect(document.activeElement).toEqual(trapContainer)
+  expect(document.activeElement).toEqual(firstButton)
 
   controller.abort()
 })
@@ -58,7 +60,7 @@ it('Should initially focus the initialFocus element when specified', () => {
   controller.abort()
 })
 
-it('Should prevent focus from exiting the trap, returns focus to previously-focused element', async () => {
+it('Should prevent focus from exiting the trap, returns focus to first element', async () => {
   const {container} = render(
     <div>
       <div id="trapContainer">
@@ -73,40 +75,25 @@ it('Should prevent focus from exiting the trap, returns focus to previously-focu
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const secondButton = trapContainer.querySelectorAll('button')[1]
   const durianButton = container.querySelector<HTMLElement>('#durian')!
+  const firstButton = trapContainer.querySelector('button')!
+  const lastButton = trapContainer.querySelectorAll('button')[2]
+
   const controller = focusTrap(trapContainer)
 
-  focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
-
-  focus(secondButton)
-  expect(document.activeElement).toEqual(secondButton)
-
-  focus(durianButton)
-  expect(document.activeElement).toEqual(secondButton)
+  lastButton.focus()
+  userEvent.tab()
+  expect(document.activeElement).toEqual(firstButton)
 
   controller.abort()
+
+  lastButton.focus()
+  userEvent.tab()
+  expect(document.activeElement).toEqual(durianButton)
 })
 
-it('Should prevent focus from exiting the trap if there are no focusable children', async () => {
-  const {container} = render(
-    <div>
-      <div id="trapContainer"></div>
-      <button id="durian" tabIndex={0}>
-        Durian
-      </button>
-    </div>
-  )
-
-  const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const durianButton = container.querySelector<HTMLElement>('#durian')!
-  const controller = focusTrap(trapContainer)
-
-  focus(durianButton)
-  expect(document.activeElement === durianButton).toEqual(false)
-
-  controller.abort()
+it('Should raise an error if there are no focusable children', async () => {
+  // TODO: Having a focus trap with no focusable children is not good for accessibility.
 })
 
 it('Should cycle focus from last element to first element and vice-versa', async () => {
@@ -130,10 +117,10 @@ it('Should cycle focus from last element to first element and vice-versa', async
   const controller = focusTrap(trapContainer)
 
   lastButton.focus()
-  fireEvent(lastButton, new KeyboardEvent('keydown', {bubbles: true, key: 'Tab'}))
+  userEvent.tab()
   expect(document.activeElement).toEqual(firstButton)
 
-  fireEvent(firstButton, new KeyboardEvent('keydown', {bubbles: true, key: 'Tab', shiftKey: true}))
+  userEvent.tab({shift: true})
   expect(document.activeElement).toEqual(lastButton)
 
   controller.abort()
@@ -155,15 +142,19 @@ it('Should should release the trap when the signal is aborted', async () => {
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
+  const firstButton = trapContainer.querySelector('button')!
+  const lastButton = trapContainer.querySelectorAll('button')[2]
 
   const controller = focusTrap(trapContainer)
 
-  focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
+  lastButton.focus()
+  userEvent.tab()
+  expect(document.activeElement).toEqual(firstButton)
 
   controller.abort()
 
-  focus(durianButton)
+  lastButton.focus()
+  userEvent.tab()
   expect(document.activeElement).toEqual(durianButton)
 })
 
@@ -185,18 +176,19 @@ it('Should should release the trap when the container is removed from the DOM', 
 
   focusTrap(trapContainer)
 
-  focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
+  durianButton.focus()
+  expect(document.activeElement).toEqual(firstButton)
 
   // empty trap and remove it from the DOM
   trapContainer.removeChild(firstButton)
   trapContainer.parentElement?.removeChild(trapContainer)
 
-  focus(durianButton)
+  durianButton.focus()
   expect(document.activeElement).toEqual(durianButton)
 })
 
 it('Should handle dynamic content', async () => {
+  // TODO: check how this was handled previously, maybe there's a better solution?
   const {container} = render(
     <div>
       <div id="trapContainer">
@@ -217,20 +209,11 @@ it('Should handle dynamic content', async () => {
 
   secondButton.focus()
   trapContainer.removeChild(thirdButton)
-  fireEvent(secondButton, new KeyboardEvent('keydown', {bubbles: true, key: 'Tab'}))
+  userEvent.tab()
   expect(document.activeElement).toEqual(firstButton)
 
-  fireEvent(firstButton, new KeyboardEvent('keydown', {bubbles: true, key: 'Tab', shiftKey: true}))
+  userEvent.tab({shift: true})
   expect(document.activeElement).toEqual(secondButton)
 
   controller.abort()
 })
-
-/**
- * Helper to handle firing the focusin event, which jest/JSDOM does not do for us.
- * @param element
- */
-function focus(element: HTMLElement) {
-  element.focus()
-  fireEvent(element, new FocusEvent('focusin', {bubbles: true}))
-}

--- a/src/utils/iterate-focusable-elements.ts
+++ b/src/utils/iterate-focusable-elements.ts
@@ -68,6 +68,16 @@ export function* iterateFocusableElements(
 }
 
 /**
+ * Returns the first focusable child of `container`. If `lastChild` is true,
+ * returns the last focusable child of `container`.
+ * @param container
+ * @param lastChild
+ */
+export function getFocusableChild(container: HTMLElement, lastChild = false) {
+  return iterateFocusableElements(container, {reverse: lastChild, strict: true, onlyTabbable: true}).next().value
+}
+
+/**
  * Determines whether the given element is focusable. If `strict` is true, we may
  * perform additional checks that require a reflow (less performant).
  * @param elem
@@ -80,7 +90,8 @@ export function isFocusable(elem: HTMLElement, strict = false): boolean {
     (elem as HTMLElement & {disabled: boolean}).disabled
   const hiddenInert = elem.hidden
   const hiddenInputInert = elem instanceof HTMLInputElement && elem.type === 'hidden'
-  if (disabledAttrInert || hiddenInert || hiddenInputInert) {
+  const sentinelInert = elem.classList.contains('sentinel')
+  if (disabledAttrInert || hiddenInert || hiddenInputInert || sentinelInert) {
     return false
   }
 


### PR DESCRIPTION
# Motivation

Precursor to this PR I'm working on: https://github.com/primer/behaviors/pull/48

This change alters the behavior of the `focusTrap` so that it inserts a sentinel `<span>` element before and after the trap area.

Note that this is a breaking change in that: when there are no focusable elements within the `focusTrap` the container itself is no longer focused. This is because from an Accessibility point of view - trapping focus and not having any focusable elements within that focus is bad for screenreader users.

I have tested this against `@primer/react` by locally wiring it up with `yarn link` and have verified that it behaves as expected however I recommend that we release this as a minor version point as a minimum (not a patch) and then test the change thoroughly before rolling it out.

## Questions:

1. What do I need to add to this PR to get it ready for release?
2. If `focusTrap` is called against a container with no focusable elements, should we raise an error?