### PR TITLE
Add `import` conditional export type

### DIFF
--- a/.changeset/thirty-gifts-clean.md
+++ b/.changeset/thirty-gifts-clean.md
@@ -1,0 +1,5 @@
+---
+"@primer/behaviors": patch
+---
+
+Add `import` conditional export type to the package for better NodeJS ESM compatibility

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
       "module": "./dist/esm/index.js",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/esm/index.d.ts"
     },
     "./utils": {
       "module": "./dist/esm/utils/index.js",
       "import": "./dist/esm/utils/index.js",
       "require": "./dist/cjs/utils/index.js",
-      "types": "./dist/utils/index.d.ts"
+      "types": "./dist/esm/utils/index.d.ts"
     }
   },
-  "types": "dist/cjs/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist",
     "utils"

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "module": "./dist/esm/index.js",
+      "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "module": "./dist/esm/index.js"
+      "types": "./dist/index.d.ts"
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
+      "module": "./dist/esm/utils/index.js",
+      "import": "./dist/esm/utils/index.js",
       "require": "./dist/cjs/utils/index.js",
-      "module": "./dist/esm/utils/index.js"
+      "types": "./dist/utils/index.d.ts"
     }
   },
   "types": "dist/cjs/index.d.ts",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@primer/behaviors/utils",
   "types": "../dist/esm/utils/index.d.ts",
-  "main": "../dist/esm/utils/index.js",
-  "type": "module",
+  "main": "../dist/cjs/utils/index.js",
+  "module": "../dist/esm/utils/index.js",
   "sideEffects": false
 }


### PR DESCRIPTION
@jaked pointed out that `module` is not officially supported by NodeJS, and is in fact an [optimization used by bundlers like Webpack](https://webpack.js.org/guides/package-exports/#providing-commonjs-and-esm-version-stateless).  We should specify `import` for ESM exports being used by Node.  This change should make it easier to use this package in environments running tests in Node, eg Jest.