### PR TITLE
Anchored position: Flip to alternative alignments on overflow

### DIFF
--- a/.changeset/rare-donuts-ring.md
+++ b/.changeset/rare-donuts-ring.md
@@ -1,0 +1,5 @@
+---
+"@primer/behaviors": patch
+---
+
+Anchored Position: Add alternative alignments to flip to if there isn't enough space

--- a/docs/anchored-position.md
+++ b/docs/anchored-position.md
@@ -29,7 +29,8 @@ Once we have the clipping container, its bounding box is used as the viewport fo
 With the positions and sizes of the above DOM elements, the algorithm calculates the (x, y) coordinate for the floating element. Then, it checks to see if, based on the floating element's size, if it would overflow the bounds of the container. If it would, it does one of two things:
 
 A) If the overflow happens in the same direction as the anchor side (e.g. side is `'outside-bottom'` and the overflowing portion of the floating element is the bottom), try to find a different side, recalculate the position, and check for overflow again. If we check all four sides and don't find one that fits, revert to the bottom side, in hopes that a scrollbar might appear.
-B) Otherwise, adjust the alignment offset so that the floating element can stay inside the container's bounds.
+B) If the overflow happens in the same direction as the anchor alignment (e.g. align is `'start'` and the overflowing portion of the floating element is the right), try to find a different alignment, recalculate the position, and check for overflow again. If we check all three alignments and don't find one that fits, revert to initial aligment, in hopes that (C) will fix it.
+C) Otherwise, adjust the alignment offset so that the floating element can stay inside the container's bounds.
 
 For a more in-depth explanation of the positioning settings, see `PositionSettings` below.
 

--- a/src/anchored-position.ts
+++ b/src/anchored-position.ts
@@ -317,16 +317,16 @@ function pureCalculateAnchoredPosition(
     // try using an alternate alignment
     const alternateAlignment = alternateAlignments[align]
 
-    let alingmentAttempt = 0
+    let alignmentAttempt = 0
     if (alternateAlignment) {
       let prevAlign = align
 
       // Try all the alternate alignments until one does not overflow
       while (
-        alingmentAttempt < alternateAlignment.length &&
+        alignmentAttempt < alternateAlignment.length &&
         shouldRecalculateAlignment(prevAlign, pos, relativeViewportRect, floatingRect)
       ) {
-        const nextAlign = alternateAlignment[alingmentAttempt++]
+        const nextAlign = alternateAlignment[alignmentAttempt++]
         prevAlign = nextAlign
 
         pos = calculatePosition(floatingRect, anchorRect, anchorSide, nextAlign, anchorOffset, alignmentOffset)


### PR DESCRIPTION
tl;dr: If there isn't enough space  for `align: 'start'`, flip alignment to `align: 'end'` (based on side alternateOrders implementation)

| Before | After |
| ------------- |-------------|
| <img width="298" alt="while in bounds, tooltip is positioned incorrectly" src="https://user-images.githubusercontent.com/1863771/161528230-79eae445-bdd0-4633-963c-76348696199e.png"> | <img width="242" alt="tooltip position is flipped" src="https://user-images.githubusercontent.com/1863771/161528204-bd8c36ad-eda6-4308-ade0-52446a7e3c47.png"> |

- [See tests for more examples](https://github.com/primer/behaviors/pull/78/files#diff-966bd08d7c9fc864ddddfa7cd59d9edfa2440704b1985bf2825253e5a1b5827bR295)
- Fixes: https://github.com/primer/behaviors/issues/63
- Video explanation: https://github.rewatch.com/video/knwsmsoh21xfkv2s-2006-720p
- Tested with primer/react: https://github.com/primer/react/pull/2006