### PR TITLE
Anchored position: Add check for boundary collision on left side

### DIFF
--- a/src/anchored-position.ts
+++ b/src/anchored-position.ts
@@ -493,6 +493,11 @@ function shouldRecalculateAlignment(
   if (align === 'end') {
     return currentPos.left < containerDimensions.left
   } else if (align === 'start' || align === 'center') {
-    return currentPos.left + elementDimensions.width > containerDimensions.left + containerDimensions.width
+    return (
+      // right edge
+      currentPos.left + elementDimensions.width > containerDimensions.left + containerDimensions.width ||
+      // left edge
+      currentPos.left < containerDimensions.left
+    )
   }
 }


### PR DESCRIPTION
I missed a boundary condition in https://github.com/primer/behaviors/pull/78 for the left side, added it now :)

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/1863771/165814534-a2fbd1cc-7e22-4a45-be73-524fa34b8c19.png) | ![image](https://user-images.githubusercontent.com/1863771/165814551-6e3f0beb-876e-4620-8ba7-dd51cf615fed.png) | 


