### PR TITLE
Use a binary search to find the insertion index for new elements managed by the focus zone

### DIFF
--- a/.changeset/gorgeous-zebras-hammer.md
+++ b/.changeset/gorgeous-zebras-hammer.md
@@ -1,0 +1,8 @@
+---
+"@primer/behaviors": patch
+---
+
+Use a binary search to find the insertion index for new elements managed by the focus zone.
+For a use case with 1000 elements managed by the focus zone, added one at a time (by react),
+this takes us from 500,000 calls to `compareDocumentPosition` over 1000ms to 8,000 calls
+over 16ms. 


### PR DESCRIPTION
If a focus zone contains a large number of elements that are added one at a time, performance can suffer. This is because we maintain a list of all focusable elements, and when new elements are added to the focus zone, we do a linear search to find the index of the first currently-managed element that is after the first newly-added element. Since the list is ordered, we can do a binary search instead.

In the repos team's use case (~1000 focusable elements), this change takes us from ~500,000 calls to `compareDocumentPosition` taking a total of about 1000ms, down to ~8,000 calls taking a total of 16ms.