### PR TITLE
FocusZone: Use custom focusInStrategy to initialize tabIndex

### DIFF
--- a/.changeset/eighty-peaches-smoke.md
+++ b/.changeset/eighty-peaches-smoke.md
@@ -1,0 +1,5 @@
+---
+"@primer/behaviors": patch
+---
+
+FocusZone: If custom `focusInStrategy` is defined, use it to initialize tabIndexes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/behaviors",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/behaviors",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.2",

--- a/src/__tests__/focus-zone.test.tsx
+++ b/src/__tests__/focus-zone.test.tsx
@@ -314,9 +314,12 @@ it('Should call the custom focusInStrategy callback', () => {
 
   const focusZoneContainer = container.querySelector<HTMLElement>('#focusZone')!
   const outsideButton = container.querySelector<HTMLElement>('#outside')!
-  const [, secondButton] = focusZoneContainer.querySelectorAll('button')
+  const [firstButton, secondButton] = focusZoneContainer.querySelectorAll('button')
   const focusInCallback = jest.fn().mockReturnValue(secondButton)
   const controller = focusZone(focusZoneContainer, {focusInStrategy: focusInCallback})
+
+  expect(firstButton.getAttribute('tabindex')).toEqual('-1')
+  expect(secondButton.getAttribute('tabindex')).toEqual('0')
 
   outsideButton.focus()
   userEvent.tab()

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -445,7 +445,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     if (!currentFocusedElement) {
-      const initialElement = typeof focusInStrategy === "function" ? focusInStrategy() : getFirstFocusableElement()
+      const initialElement = typeof focusInStrategy === "function" ? focusInStrategy(null) : getFirstFocusableElement()
       updateFocusedElement(initialElement)
     }
   }

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -445,7 +445,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     if (!currentFocusedElement) {
-      const initialElement = typeof focusInStrategy === "function" ? focusInStrategy(null) : getFirstFocusableElement()
+      const initialElement = typeof focusInStrategy === 'function' ? focusInStrategy(document.body) : getFirstFocusableElement()
       updateFocusedElement(initialElement)
     }
   }

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -510,7 +510,9 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
   beginFocusManagement(...iterateFocusableElements(container))
 
   // Open the first tabbable element for tabbing
-  updateFocusedElement(getFirstFocusableElement())
+  const initialElement =
+    typeof focusInStrategy === 'function' ? focusInStrategy(document.body) : getFirstFocusableElement()
+  updateFocusedElement(initialElement)
 
   // If the DOM structure of the container changes, make sure we keep our state up-to-date
   // with respect to the focusable elements cache and its order

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -445,7 +445,8 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     if (!currentFocusedElement) {
-      const initialElement = typeof focusInStrategy === 'function' ? focusInStrategy(document.body) : getFirstFocusableElement()
+      const initialElement =
+        typeof focusInStrategy === 'function' ? focusInStrategy(document.body) : getFirstFocusableElement()
       updateFocusedElement(initialElement)
     }
   }

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -445,9 +445,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     if (!currentFocusedElement) {
-      const initialElement =
-        typeof focusInStrategy === 'function' ? focusInStrategy(document.body) : getFirstFocusableElement()
-      updateFocusedElement(initialElement)
+      updateFocusedElement(getFirstFocusableElement())
     }
   }
 

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -445,7 +445,8 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     if (!currentFocusedElement) {
-      updateFocusedElement(getFirstFocusableElement())
+      const initialElement = typeof focusInStrategy === "function" ? focusInStrategy() : getFirstFocusableElement()
+      updateFocusedElement(initialElement)
     }
   }
 


### PR DESCRIPTION
## Context

[Slack conversation](https://github.slack.com/archives/C0FSWLQ0Y/p1675807376731229?thread_ts=1675799238.444799&cid=C0FSWLQ0Y)

## Problem

The first focusable element in a focus zone always has `tabIndex=0` even if a custom `focusInStrategy` function is defined. This sometimes causes NVDA to focus the wrong initial element (see https://github.com/github/primer/issues/1114#issuecomment-1421275869)

## Solution

If a custom `focusInStrategy` is defined, use it to initialize the tab indexes.