### PR TITLE
ci: update dependabot config to include github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    labels:
+      - 'dependencies'
+      - 'skip changeset'
 
   - package-ecosystem: 'npm'
     directory: '/docs'
@@ -16,3 +19,14 @@ updates:
       interval: 'daily'
     allow:
       - dependency-name: '@primer/gatsby-theme-doctocat'
+    labels:
+      - 'dependencies'
+      - 'skip changeset'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+      - 'skip changeset'


### PR DESCRIPTION
Update our `dependabot` config to include support for checking GitHub Actions versions. Also update the config to apply the `dependencies` and `skip changeset` label.