### PR TITLE
Add IterateFocusableElements options to focusZone

### DIFF
--- a/.changeset/neat-timers-tease.md
+++ b/.changeset/neat-timers-tease.md
@@ -1,0 +1,5 @@
+---
+'@primer/behaviors': minor
+---
+
+Add IterateFocusableElements options to focusZone

--- a/src/__tests__/focus-trap.test.tsx
+++ b/src/__tests__/focus-trap.test.tsx
@@ -17,6 +17,26 @@ beforeAll(() => {
       getClientRects: {
         get: () => () => [42],
       },
+      offsetParent: {
+        get() {
+          // eslint-disable-next-line @typescript-eslint/no-this-alias
+          for (let element = this; element; element = element.parentNode) {
+            if (element.style?.display?.toLowerCase() === 'none') {
+              return null
+            }
+          }
+
+          if (this.style?.position?.toLowerCase() === 'fixed') {
+            return null
+          }
+
+          if (this.tagName.toLowerCase() in ['html', 'body']) {
+            return null
+          }
+
+          return this.parentNode
+        },
+      },
     })
   } catch {
     // ignore
@@ -40,7 +60,7 @@ it('Should initially focus the first element when activated', () => {
   const controller = focusTrap(trapContainer)
   expect(document.activeElement).toEqual(firstButton)
 
-  controller.abort()
+  controller?.abort()
 })
 
 it('Should initially focus the initialFocus element when specified', () => {
@@ -57,7 +77,7 @@ it('Should initially focus the initialFocus element when specified', () => {
   const controller = focusTrap(trapContainer, secondButton)
   expect(document.activeElement).toEqual(secondButton)
 
-  controller.abort()
+  controller?.abort()
 })
 
 it('Should prevent focus from exiting the trap, returns focus to first element', async () => {
@@ -86,7 +106,7 @@ it('Should prevent focus from exiting the trap, returns focus to first element',
   await user.tab()
   expect(document.activeElement).toEqual(firstButton)
 
-  controller.abort()
+  controller?.abort()
 
   lastButton.focus()
   await user.tab()
@@ -125,7 +145,7 @@ it('Should cycle focus from last element to first element and vice-versa', async
   await user.tab({shift: true})
   expect(document.activeElement).toEqual(lastButton)
 
-  controller.abort()
+  controller?.abort()
 })
 
 it('Should should release the trap when the signal is aborted', async () => {
@@ -154,7 +174,7 @@ it('Should should release the trap when the signal is aborted', async () => {
   await user.tab()
   expect(document.activeElement).toEqual(firstButton)
 
-  controller.abort()
+  controller?.abort()
 
   lastButton.focus()
   await user.tab()
@@ -218,5 +238,5 @@ it('Should handle dynamic content', async () => {
   await user.tab({shift: true})
   expect(document.activeElement).toEqual(secondButton)
 
-  controller.abort()
+  controller?.abort()
 })

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -1,6 +1,6 @@
 import {polyfill as eventListenerSignalPolyfill} from './polyfills/event-listener-signal.js'
 import {isMacOS} from './utils/user-agent.js'
-import {iterateFocusableElements} from './utils/iterate-focusable-elements.js'
+import {IterateFocusableElements, iterateFocusableElements} from './utils/iterate-focusable-elements.js'
 import {uniqueId} from './utils/unique-id.js'
 
 eventListenerSignalPolyfill()
@@ -114,7 +114,7 @@ const KEY_TO_DIRECTION = {
 /**
  * Options that control the behavior of the arrow focus behavior.
  */
-export interface FocusZoneSettings {
+export type FocusZoneSettings = IterateFocusableElements & {
   /**
    * Choose the behavior applied in cases where focus is currently at either the first or
    * last element of the container.
@@ -504,8 +504,13 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
   }
 
+  const iterateFocusableElementsOptions: IterateFocusableElements = {
+    reverse: settings?.reverse,
+    strict: settings?.strict,
+    onlyTabbable: settings?.onlyTabbable,
+  }
   // Take all tabbable elements within container under management
-  beginFocusManagement(...iterateFocusableElements(container))
+  beginFocusManagement(...iterateFocusableElements(container, iterateFocusableElementsOptions))
 
   // Open the first tabbable element for tabbing
   const initialElement =
@@ -519,14 +524,14 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     for (const mutation of mutations) {
       for (const removedNode of mutation.removedNodes) {
         if (removedNode instanceof HTMLElement) {
-          endFocusManagement(...iterateFocusableElements(removedNode))
+          endFocusManagement(...iterateFocusableElements(removedNode, iterateFocusableElementsOptions))
         }
       }
     }
     for (const mutation of mutations) {
       for (const addedNode of mutation.addedNodes) {
         if (addedNode instanceof HTMLElement) {
-          beginFocusManagement(...iterateFocusableElements(addedNode))
+          beginFocusManagement(...iterateFocusableElements(addedNode, iterateFocusableElementsOptions))
         }
       }
     }

--- a/src/utils/iterate-focusable-elements.ts
+++ b/src/utils/iterate-focusable-elements.ts
@@ -98,10 +98,12 @@ export function isFocusable(elem: HTMLElement, strict = false): boolean {
   // Each of the conditions checked below require a reflow, thus are gated by the `strict`
   // argument. If any are true, the element is not focusable, even if tabindex is set.
   if (strict) {
+    const style = getComputedStyle(elem)
     const sizeInert = elem.offsetWidth === 0 || elem.offsetHeight === 0
-    const visibilityInert = ['hidden', 'collapse'].includes(getComputedStyle(elem).visibility)
+    const visibilityInert = ['hidden', 'collapse'].includes(style.visibility)
+    const displayInert = style.display === 'none' || !elem.offsetParent
     const clientRectsInert = elem.getClientRects().length === 0
-    if (sizeInert || visibilityInert || clientRectsInert) {
+    if (sizeInert || visibilityInert || clientRectsInert || displayInert) {
       return false
     }
   }


### PR DESCRIPTION
### Background: 
We ran into a bug when using `useFocusZone` in our component where when the css visibility is set to "hidden" the user is unable to tab past the element. I noticed `iterateFocusableElements` has a `strict` option that checks for elements with hidden visibility but `useFocusZone` does not support the `strict` argument to be passed through to `iterateFocusableElements`. We would like to enable strict mode in `useFocusZone` to remove `visibility: hidden` elements as focusable elements.

More details on the bug: https://github.com/github/issues/issues/7911

### What are you trying to accomplish?

Add ability in [focus zone](https://github.com/primer/react/blob/main/src/hooks/useFocusZone.ts#L53) to pass through settings options to `iterateFocusableElements`. Also, I added an additional check to not focus on elements that have "display: none" on the element and its parents