### PR TITLE
Create workflow to add primer/behaviors issues to the Primer teams backlog for triage

### DIFF
--- a/.github/workflows/add-to-inbox.yml
+++ b/.github/workflows/add-to-inbox.yml
@@ -1,0 +1,38 @@
+name: Add to Inbox 📥
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  add-to-inbox:
+    if: ${{ github.repository == 'primer/behaviors' }}
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      PROJECT_ID: 4503
+    steps:
+      - id: get-primer-access-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID }}
+          private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY }}
+      - name: Add rails label to issue
+        run: |
+          gh issue edit $ISSUE_URL --add-label rails
+        env:
+          GH_TOKEN: ${{ steps.get-primer-access-token.outputs.token }}
+      - name: Add react label to issue
+        run: |
+          gh issue edit $ISSUE_URL --add-label react
+        env:
+          GH_TOKEN: ${{ steps.get-primer-access-token.outputs.token }}
+      - id: get-github-access-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID_FOR_GITHUB }}
+          private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY_FOR_GITHUB }}
+          owner: github
+      - name: Add issue to project
+        run: gh project item-add $PROJECT_ID --url $ISSUE_URL --owner github
+        env:
+          GH_TOKEN: ${{ steps.get-github-access-token.outputs.token }}

--- a/.github/workflows/add-to-inbox.yml
+++ b/.github/workflows/add-to-inbox.yml
@@ -16,14 +16,9 @@ jobs:
         with:
           app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID }}
           private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY }}
-      - name: Add rails label to issue
+      - name: Add labels to issue
         run: |
-          gh issue edit $ISSUE_URL --add-label rails
-        env:
-          GH_TOKEN: ${{ steps.get-primer-access-token.outputs.token }}
-      - name: Add react label to issue
-        run: |
-          gh issue edit $ISSUE_URL --add-label react
+          gh issue edit $ISSUE_URL --add-label 'rails,react'
         env:
           GH_TOKEN: ${{ steps.get-primer-access-token.outputs.token }}
       - id: get-github-access-token


### PR DESCRIPTION
I noticed recently that issues filed in the `primer/behaviors` repo don't end up in our inbox for triage (e.g. https://github.com/orgs/github/projects/4503), so are likely getting missed. 

This PR attempts to create an "add to inbox" workflow for this repo so that new and reopened issues will get labelled as `react` and `rails` (so we can discuss at the appropriate weekly maintainer syncs) and moved into the Inbox of the [Primer teams backlog](https://github.com/orgs/github/projects/4503).

Questions:
- Are all of the `vars`, `steps`, and `secrets` used in this workflow valid? I assumed these values are defined in the specified actions, but would be good to confirm.
- Any other ideas for a better triage plan for `primer/behaviors` issues?