### PR TITLE
Position calculation is sus when the floating element is larger than viewport.

### DIFF
--- a/src/__tests__/anchored-position.test.ts
+++ b/src/__tests__/anchored-position.test.ts
@@ -375,7 +375,6 @@ describe('getAnchoredPosition', () => {
     const {float, anchor} = createVirtualDOM(parentRect, anchorRect, floatingRect)
     const settings: Partial<PositionSettings> = {side: 'outside-bottom', align: 'start'}
     const {top, left, anchorSide, anchorAlign} = getAnchoredPosition(float, anchor, settings)
-    // Not really sure what to expect here.
     expect(anchorSide).toEqual('outside-right')
     expect(anchorAlign).toEqual('start')
     expect(top).toEqual(0)

--- a/src/__tests__/anchored-position.test.ts
+++ b/src/__tests__/anchored-position.test.ts
@@ -378,7 +378,7 @@ describe('getAnchoredPosition', () => {
     // Not really sure what to expect here.
     expect(anchorSide).toEqual('outside-right')
     expect(anchorAlign).toEqual('start')
-    expect(top).toEqual(-28) // should be 16 which is the top start of the anchor element. Negative value is wrong.
+    expect(top).toEqual(0)
     expect(left).toEqual(52)
   })
 })

--- a/src/__tests__/anchored-position.test.ts
+++ b/src/__tests__/anchored-position.test.ts
@@ -369,16 +369,16 @@ describe('getAnchoredPosition', () => {
 
   // This test runs for values derived from a real use case https://github.com/github/accessibility-audits/issues/4515 as run on a local storybook.
   it('should overflow to bottom if the element is too tall to fit on the screen when zoomed', () => {
-    const parentRect = makeDOMRect(0, 0, 0, 0)
+    const parentRect = makeDOMRect(0, 0, 400, 400)
     const anchorRect = makeDOMRect(16, 16, 32, 32) // left aligned button
-    const floatingRect = makeDOMRect(0, 0, 256, 428) // 428 is the max height of the screen
+    const floatingRect = makeDOMRect(0, 0, 256, 428)
     const {float, anchor} = createVirtualDOM(parentRect, anchorRect, floatingRect)
     const settings: Partial<PositionSettings> = {side: 'outside-bottom', align: 'start'}
     const {top, left, anchorSide, anchorAlign} = getAnchoredPosition(float, anchor, settings)
     // Not really sure what to expect here.
-    expect(anchorSide).toEqual('outside-bottom')
-    expect(anchorAlign).toEqual('center')
-    expect(top).toEqual(52)
-    expect(left).toEqual(-256) // Expecting 32, Receiving -256
+    expect(anchorSide).toEqual('outside-right')
+    expect(anchorAlign).toEqual('start')
+    expect(top).toEqual(-28) // should be 16 which is the top start of the anchor element. Negative value is wrong.
+    expect(left).toEqual(52)
   })
 })

--- a/src/__tests__/anchored-position.test.ts
+++ b/src/__tests__/anchored-position.test.ts
@@ -366,4 +366,19 @@ describe('getAnchoredPosition', () => {
     expect(top).toEqual(54) // anchorRect.top + anchorRect.height + (settings.anchorOffset ?? 4) - parentRect.top
     expect(left).toEqual(380) // anchorRect.left + anchorRect.width - parentRect.left - floatingRect.width
   })
+
+  // This test runs for values derived from a real use case https://github.com/github/accessibility-audits/issues/4515 as run on a local storybook.
+  it('should overflow to bottom if the element is too tall to fit on the screen when zoomed', () => {
+    const parentRect = makeDOMRect(0, 0, 0, 0)
+    const anchorRect = makeDOMRect(16, 16, 32, 32) // left aligned button
+    const floatingRect = makeDOMRect(0, 0, 256, 428) // 428 is the max height of the screen
+    const {float, anchor} = createVirtualDOM(parentRect, anchorRect, floatingRect)
+    const settings: Partial<PositionSettings> = {side: 'outside-bottom', align: 'start'}
+    const {top, left, anchorSide, anchorAlign} = getAnchoredPosition(float, anchor, settings)
+    // Not really sure what to expect here.
+    expect(anchorSide).toEqual('outside-bottom')
+    expect(anchorAlign).toEqual('center')
+    expect(top).toEqual(52)
+    expect(left).toEqual(-256) // Expecting 32, Receiving -256
+  })
 })

--- a/src/anchored-position.ts
+++ b/src/anchored-position.ts
@@ -370,7 +370,8 @@ function pureCalculateAnchoredPosition(
     // likely to be able to scroll.
     if (alternateOrder && positionAttempt < alternateOrder.length) {
       if (pos.top + floatingRect.height > viewportRect.height + relativeViewportRect.top) {
-        pos.top = viewportRect.height + relativeViewportRect.top - floatingRect.height
+        // This prevents top from being a negative value
+        pos.top = Math.max(viewportRect.height + relativeViewportRect.top - floatingRect.height, 0)
       }
     }
   }


### PR DESCRIPTION
While debugging https://github.com/github/accessibility-audits/issues/4515 , I was able to narrow down the issue to this criteria.

When zoomed in, the floating element becomes of larger in height compared to the viewport. This results in negative `top` value in the anchor position calculation. Thus results in top parts of the floating element being cut off. 
Before I can try to fix this by messing with the super complex calculations, I thought I'd float a test case to see if my assumptions are right.

I tried to keep the test case values as close to the real life use case as possible. You can see that the height of the floating element is `428px` and the height of the viewport is only `400px`. This already results in a negative `top` value which is buggy as far as I understand.

Open to feedback