### PR TITLE
Update release.yml to use tagged dependency

### DIFF
--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -10,7 +10,7 @@ jobs:
   release-canary:
     name: npm
     if: ${{ github.repository == 'primer/behaviors' }}
-    uses: primer/.github/.github/workflows/release_canary.yml@main
+    uses: primer/.github/.github/workflows/release_canary.yml@v1.0.0
     with:
       install: npm i
     secrets:

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -8,7 +8,7 @@ jobs:
   release-candidate:
     name: npm
     if: ${{ github.repository == 'primer/behaviors' }}
-    uses: primer/.github/.github/workflows/release_candidate.yml@main
+    uses: primer/.github/.github/workflows/release_candidate.yml@v1.0.0
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
This should have no impact. The dependency is not changed, but this reference is more secure and allows us to modify primer/.github/.github/workflows/release_with_app.yml without breaking consumers code.