### PR TITLE
Remove options when ending focus management

### DIFF
--- a/.changeset/smooth-terms-wait.md
+++ b/.changeset/smooth-terms-wait.md
@@ -1,0 +1,5 @@
+---
+'@primer/behaviors': patch
+---
+
+Fix bug found when removing nodes in a focus zone with strict mode enabled

--- a/src/__tests__/focus-zone.test.tsx
+++ b/src/__tests__/focus-zone.test.tsx
@@ -1,5 +1,5 @@
 import {FocusKeys, FocusZoneSettings, focusZone} from '../focus-zone.js'
-import {fireEvent, render, screen} from '@testing-library/react'
+import {fireEvent, render} from '@testing-library/react'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -524,7 +524,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     for (const mutation of mutations) {
       for (const removedNode of mutation.removedNodes) {
         if (removedNode instanceof HTMLElement) {
-          endFocusManagement(...iterateFocusableElements(removedNode, iterateFocusableElementsOptions))
+          endFocusManagement(...iterateFocusableElements(removedNode))
         }
       }
       // If an element is hidden or disabled, remove it from the list of focusable elements


### PR DESCRIPTION
### Context
- Related to: https://github.com/primer/behaviors/pull/235
- Related to: https://github.com/github/repos/issues/11731

### What are you trying to accomplish?
Fix bug found when removing nodes in a focus zone and with strict mode enabled. Also, I added a test to check for this.

### What approach did you choose and why?
We were running into focus inconsistencies when using `useFocusZone` in our component. I pinpointed it to [this line](https://github.com/primer/behaviors/blob/b8a107fbf3d8d10d78490c988a1275fe51f5a010/src/focus-zone.ts#L527) 
```
      if (removedNode instanceof HTMLElement) {
          endFocusManagement(...iterateFocusableElements(removedNode, iterateFocusableElementsOptions))
       }
```
where an empty array was being returned from 
```
         iterateFocusableElements(removedNode, iterateFocusableElementsOptions)
```
and the `endFocusManagement` is unable to remove the focusable elements causing jumpy focus behavior for the user. 

This was because in our component, we passed `strict=true` in the `iterateFocusableElementsOptions` object, which hits [these lines of strict checks inside `iterateFocusableElements`](https://github.com/primer/behaviors/blob/main/src/utils/iterate-focusable-elements.ts#L100-L109). Because the node no longer existed/was removed, the `strict` check failed and returned an empty array.

I removed the `iterateFocusableElementsOptions` argument so when a node is removed all focusable elements within it are removed from the `focusableElements` list
