### PR TITLE
Add observer to focus-trap

### DIFF
--- a/.changeset/curly-lions-cheat.md
+++ b/.changeset/curly-lions-cheat.md
@@ -1,0 +1,5 @@
+---
+'@primer/behaviors': patch
+---
+
+Adds mutation observer to `focus-trap` to ensure sentinel elements are always in the correct position

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -40,6 +40,7 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
 
         const [sentinelStart, sentinelEnd] = sentinels
 
+        // Adds back sentinel to correct position in the DOM
         if (!firstChild?.classList.contains('sentinel')) container.insertAdjacentElement('afterbegin', sentinelStart)
         if (!lastChild?.classList.contains('sentinel')) container.insertAdjacentElement('beforeend', sentinelEnd)
       }

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -37,6 +37,15 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
     for (const mutation of mutations) {
       console.log('Mutations:', mutations)
       if (mutation.type === 'childList' && mutation.addedNodes.length) {
+        const sentinelChildren = Array.from(
+          mutation.addedNodes,
+          e => e instanceof HTMLElement && e.classList.contains('sentinel') && e.tagName === 'SPAN',
+        )
+
+        // If any of the added nodes are sentinels, don't do anything
+        if (sentinelChildren.length) {
+          return
+        }
         console.log('ChildList Mutation')
         // If the first and last children of container aren't sentinels, move them to the start and end
         const firstChild = container.firstElementChild

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -38,8 +38,10 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
         const firstChild = container.firstElementChild
         const lastChild = container.lastElementChild
 
-        if (!firstChild?.classList.contains('sentinel')) container.insertAdjacentElement('afterbegin', sentinels[0])
-        if (!lastChild?.classList.contains('sentinel')) container.insertAdjacentElement('beforeend', sentinels[1])
+        const [sentinelStart, sentinelEnd] = sentinels
+
+        if (!firstChild?.classList.contains('sentinel')) container.insertAdjacentElement('afterbegin', sentinelStart)
+        if (!lastChild?.classList.contains('sentinel')) container.insertAdjacentElement('beforeend', sentinelEnd)
       }
     }
   })

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -34,8 +34,7 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
   const observer = new MutationObserver(mutations => {
     for (const mutation of mutations) {
       if (mutation.type === 'childList' && mutation.addedNodes.length) {
-        const sentinelChildren = Array.from(
-          mutation.addedNodes,
+        const sentinelChildren = Array.from(mutation.addedNodes).filter(
           e => e instanceof HTMLElement && e.classList.contains('sentinel') && e.tagName === 'SPAN',
         )
 

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -31,9 +31,13 @@ function followSignal(signal: AbortSignal): AbortController {
 }
 
 function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
+  console.log('Observe Focus Trap Init')
   const observer = new MutationObserver(mutations => {
+    console.log('New mutation')
     for (const mutation of mutations) {
+      console.log('Mutations:', mutations)
       if (mutation.type === 'childList' && mutation.addedNodes.length) {
+        console.log('ChildList Mutation')
         // If the first and last children of container aren't sentinels, move them to the start and end
         const firstChild = container.firstElementChild
         const lastChild = container.lastElementChild
@@ -41,8 +45,14 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
         const [sentinelStart, sentinelEnd] = sentinels
 
         // Adds back sentinel to correct position in the DOM
-        if (!firstChild?.classList.contains('sentinel')) container.insertAdjacentElement('afterbegin', sentinelStart)
-        if (!lastChild?.classList.contains('sentinel')) container.insertAdjacentElement('beforeend', sentinelEnd)
+        if (!firstChild?.classList.contains('sentinel')) {
+          container.insertAdjacentElement('afterbegin', sentinelStart)
+          console.log('Adjust sentinel to start')
+        }
+        if (!lastChild?.classList.contains('sentinel')) {
+          container.insertAdjacentElement('beforeend', sentinelEnd)
+          console.log('Adjust sentinel to end')
+        }
       }
     }
   })

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -31,11 +31,8 @@ function followSignal(signal: AbortSignal): AbortController {
 }
 
 function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
-  console.log('Observe Focus Trap Init')
   const observer = new MutationObserver(mutations => {
-    console.log('New mutation')
     for (const mutation of mutations) {
-      console.log('Mutations:', mutations)
       if (mutation.type === 'childList' && mutation.addedNodes.length) {
         const sentinelChildren = Array.from(
           mutation.addedNodes,
@@ -46,7 +43,6 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
         if (sentinelChildren.length) {
           return
         }
-        console.log('ChildList Mutation')
         // If the first and last children of container aren't sentinels, move them to the start and end
         const firstChild = container.firstElementChild
         const lastChild = container.lastElementChild
@@ -56,11 +52,9 @@ function observeFocusTrap(container: HTMLElement, sentinels: HTMLElement[]) {
         // Adds back sentinel to correct position in the DOM
         if (!firstChild?.classList.contains('sentinel')) {
           container.insertAdjacentElement('afterbegin', sentinelStart)
-          console.log('Adjust sentinel to start')
         }
         if (!lastChild?.classList.contains('sentinel')) {
           container.insertAdjacentElement('beforeend', sentinelEnd)
-          console.log('Adjust sentinel to end')
         }
       }
     }


### PR DESCRIPTION
## Summary
Adds a mutation observer to `focus-trap` that ensures that the `sentinel` elements stay at the start/end. The observer only checks for added elements that are direct descendants of the container, meaning that children of those descendants shouldn't trigger the observer.

<hr aria-hidden="true" />

### New Tests:
* Added a test to verify that sentinel elements remain at the start and end of the inner container when new elements are added. (`src/__tests__/focus-trap.test.tsx`)
* Added a test to ensure the mutation observer is removed when the focus trap is released. (`src/__tests__/focus-trap.test.tsx`)

### Focus Trap Enhancements:
* Implemented `observeFocusTrap` function to create a `MutationObserver` that maintains sentinel elements at the correct positions. (`src/focus-trap.ts`)
* Integrated the `observeFocusTrap` function into the `focusTrap` function to observe changes in the container and reposition sentinel elements as needed. (`src/focus-trap.ts`)
* Ensured the `MutationObserver` is disconnected when the focus trap is released to prevent memory leaks. (`src/focus-trap.ts`)