### PR TITLE
[FocusZone] Clear all active descendants

### DIFF
--- a/.changeset/long-lizards-pump.md
+++ b/.changeset/long-lizards-pump.md
@@ -1,0 +1,5 @@
+---
+'@primer/behaviors': minor
+---
+
+Ensure focusZone() clears all potential active descendants

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,5 @@
 import typescript from '@rollup/plugin-typescript'
-import packageJson from './package.json' assert {type: 'json'}
+import packageJson from './package.json' with {type: 'json'}
 
 const dependencyTypes = ['peerDependencies', 'dependencies', 'devDependencies']
 const dependencies = new Set(

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -424,7 +424,11 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
 
     activeDescendantControl?.removeAttribute('aria-activedescendant')
     container.removeAttribute(hasActiveDescendantAttribute)
-    previouslyActiveElement?.removeAttribute(isActiveDescendantAttribute)
+
+    for (const item of container.querySelectorAll(`[${isActiveDescendantAttribute}]`)) {
+      item?.removeAttribute(isActiveDescendantAttribute)
+    }
+
     activeDescendantCallback?.(undefined, previouslyActiveElement, false)
   }
 
@@ -580,13 +584,17 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
   )
 
   if (activeDescendantControl) {
-    container.addEventListener('focusin', event => {
-      if (event.target instanceof HTMLElement && focusableElements.includes(event.target)) {
-        // Move focus to the activeDescendantControl if one of the descendants is focused
-        activeDescendantControl.focus({preventScroll})
-        updateFocusedElement(event.target)
-      }
-    })
+    container.addEventListener(
+      'focusin',
+      event => {
+        if (event.target instanceof HTMLElement && focusableElements.includes(event.target)) {
+          // Move focus to the activeDescendantControl if one of the descendants is focused
+          activeDescendantControl.focus({preventScroll})
+          updateFocusedElement(event.target)
+        }
+      },
+      {signal},
+    )
     container.addEventListener(
       'mousemove',
       ({target}) => {
@@ -604,17 +612,25 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     )
 
     // Listeners specifically on the controlling element
-    activeDescendantControl.addEventListener('focusin', () => {
-      // Focus moved into the active descendant input.  Activate current or first descendant.
-      if (!currentFocusedElement) {
-        updateFocusedElement(getFirstFocusableElement())
-      } else {
-        setActiveDescendant(undefined, currentFocusedElement)
-      }
-    })
-    activeDescendantControl.addEventListener('focusout', () => {
-      clearActiveDescendant()
-    })
+    activeDescendantControl.addEventListener(
+      'focusin',
+      () => {
+        // Focus moved into the active descendant input.  Activate current or first descendant.
+        if (!currentFocusedElement) {
+          updateFocusedElement(getFirstFocusableElement())
+        } else {
+          setActiveDescendant(undefined, currentFocusedElement)
+        }
+      },
+      {signal},
+    )
+    activeDescendantControl.addEventListener(
+      'focusout',
+      () => {
+        clearActiveDescendant()
+      },
+      {signal},
+    )
   } else {
     // This is called whenever focus enters an element in the container
     container.addEventListener(

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -424,6 +424,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
 
     activeDescendantControl?.removeAttribute('aria-activedescendant')
     container.removeAttribute(hasActiveDescendantAttribute)
+    previouslyActiveElement?.removeAttribute(isActiveDescendantAttribute)
 
     for (const item of container.querySelectorAll(`[${isActiveDescendantAttribute}]`)) {
       item?.removeAttribute(isActiveDescendantAttribute)


### PR DESCRIPTION
This PR makes several changes to focus-zone:

1. Passes the abort controller's `signal` to several event listeners where it is currently missing.
2. Changes `clearActiveDescendant` to loop over all child elements with the `data-is-active-descendant` attribute and removes it from each. The current behavior only removes the attribute from a single element, which is a problem in React apps because React re-uses elements with the same key, resulting in more than one element being marked as the active descendant.