### PR TITLE
Focus-trap: Add delay when a focus trap already exists

### DIFF
--- a/.changeset/ninety-humans-chew.md
+++ b/.changeset/ninety-humans-chew.md
@@ -1,0 +1,5 @@
+---
+'@primer/behaviors': patch
+---
+
+Adds slight delay to setting focus initially when a focus trap already exists

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -115,23 +115,38 @@ export function focusTrap(
         lastFocusedChild = focusedElement
         return
       } else {
+        const focusDelay = suspendedTrapStack.length > 0 ? 50 : undefined
+
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
-          lastFocusedChild.focus()
+          handleFocus(lastFocusedChild, focusDelay)
           return
         } else if (initialFocus && container.contains(initialFocus)) {
-          initialFocus.focus()
+          handleFocus(initialFocus, focusDelay)
           return
         } else {
           const firstFocusableChild = getFocusableChild(container)
-          firstFocusableChild?.focus()
+          handleFocus(firstFocusableChild, focusDelay)
           return
         }
       }
     }
   }
 
-  const wrappingController = followSignal(signal)
+  function handleFocus(focusTarget: HTMLElement | undefined, delay?: number) {
+    if (!focusTarget) return
 
+    if (delay) {
+      setTimeout(() => {
+        focusTarget.focus()
+      }, delay)
+
+      return
+    }
+
+    focusTarget.focus()
+  }
+
+  const wrappingController = followSignal(signal)
   if (activeTrap) {
     const suspendedTrap = activeTrap
     activeTrap.container.setAttribute('data-focus-trap', 'suspended')

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -139,8 +139,6 @@ export function focusTrap(
       setTimeout(() => {
         focusTarget.focus()
       }, delay)
-
-      return
     }
 
     focusTarget.focus()

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -115,7 +115,7 @@ export function focusTrap(
         lastFocusedChild = focusedElement
         return
       } else {
-        const focusDelay = suspendedTrapStack.length > 0 ? 50 : undefined
+        const focusDelay = suspendedTrapStack.length > 0 ? 100 : undefined
 
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
           handleFocus(lastFocusedChild, focusDelay)


### PR DESCRIPTION
Fix for https://github.com/github/primer/issues/4576

In Safari with VoiceOver (VO), when opening a dialog inside of a dialog, the secondary dialog's presence will not be announced when using VO. 

Adding a slight delay (`50ms`) fixes this, as it provides VO with additional time to move the VO cursor to the secondary dialog.