### PR TITLE
Accessibility issue: Remove tab index 0

### DIFF
--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -82,7 +82,6 @@ export function focusTrap(
   container.setAttribute('data-focus-trap', 'active')
   const sentinelStart = document.createElement('span')
   sentinelStart.setAttribute('class', 'sentinel')
-  sentinelStart.setAttribute('tabindex', '0')
   sentinelStart.setAttribute('aria-hidden', 'true')
   sentinelStart.onfocus = () => {
     const lastFocusableChild = getFocusableChild(container, true)


### PR DESCRIPTION
I'm creating this PR partially as a means of starting a conversation around it. I don't have full context working on primer and likely will need some support.

My team has a dropdown that lives in the github ui monolith. This component uses the `AnchoredOverlay` react component. When reviewing our feature, our accessibility designer, @mattobee found this issue:

> there are two instances of span elements that have simultaneously been hidden from assistive technology with an aria-hidden attribute while also being made focusable with tabindex="0".
> `<span class="sentinel" tabindex="0" aria-hidden="true"></span>`
> The tabindex attribute should be removed from these elements.

Pulled from: https://github.com/github/sweagentd/issues/5140

I found this ADR that discusses the complexity of the component: https://github.com/primer/react/blob/9acebe1308dfef6141b097bfd153f4c4b03d13c9/contributor-docs/adrs/adr-009-behavior-isolation.md?plain=1#L49C198-L49C305

Will removing tabindex break expected behavior? Is there some other way of making this component accessible?

Thanks!