### PR TITLE
More performant and less memory usage to add elements to focusableElements indexing

### DIFF
--- a/src/__tests__/indexed-set.test.ts
+++ b/src/__tests__/indexed-set.test.ts
@@ -4,7 +4,7 @@ describe('IndexedSet', () => {
   describe('insertAt', () => {
     it('inserts elements at the specified index', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect(set.get(0)).toBe('a')
       expect(set.get(1)).toBe('b')
@@ -14,8 +14,8 @@ describe('IndexedSet', () => {
 
     it('inserts elements in the middle', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'c')
-      set.insertAt(1, 'b')
+      set.insertAt(0, ['a', 'c'])
+      set.insertAt(1, ['b'])
 
       expect(set.get(0)).toBe('a')
       expect(set.get(1)).toBe('b')
@@ -24,8 +24,8 @@ describe('IndexedSet', () => {
 
     it('deduplicates elements', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b')
-      set.insertAt(2, 'b', 'c') // 'b' should be ignored
+      set.insertAt(0, ['a', 'b'])
+      set.insertAt(2, ['b', 'c']) // 'b' should be ignored
 
       expect(set.size).toBe(3)
       expect(set.get(0)).toBe('a')
@@ -35,8 +35,8 @@ describe('IndexedSet', () => {
 
     it('handles inserting all duplicates', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b')
-      set.insertAt(0, 'a', 'b') // all duplicates
+      set.insertAt(0, ['a', 'b'])
+      set.insertAt(0, ['a', 'b']) // all duplicates
 
       expect(set.size).toBe(2)
     })
@@ -45,7 +45,7 @@ describe('IndexedSet', () => {
   describe('delete', () => {
     it('removes an element and returns true', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect(set.delete('b')).toBe(true)
       expect(set.size).toBe(2)
@@ -56,7 +56,7 @@ describe('IndexedSet', () => {
 
     it('returns false for non-existent element', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a')
+      set.insertAt(0, ['a'])
 
       expect(set.delete('b')).toBe(false)
       expect(set.size).toBe(1)
@@ -66,7 +66,7 @@ describe('IndexedSet', () => {
   describe('has', () => {
     it('returns true for existing elements', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b')
+      set.insertAt(0, ['a', 'b'])
 
       expect(set.has('a')).toBe(true)
       expect(set.has('b')).toBe(true)
@@ -74,14 +74,14 @@ describe('IndexedSet', () => {
 
     it('returns false for non-existent elements', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a')
+      set.insertAt(0, ['a'])
 
       expect(set.has('b')).toBe(false)
     })
 
     it('returns false after element is deleted', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a')
+      set.insertAt(0, ['a'])
       set.delete('a')
 
       expect(set.has('a')).toBe(false)
@@ -91,7 +91,7 @@ describe('IndexedSet', () => {
   describe('indexOf', () => {
     it('returns the index of an existing element', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect(set.indexOf('a')).toBe(0)
       expect(set.indexOf('b')).toBe(1)
@@ -100,7 +100,7 @@ describe('IndexedSet', () => {
 
     it('returns -1 for non-existent elements', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a')
+      set.insertAt(0, ['a'])
 
       expect(set.indexOf('b')).toBe(-1)
     })
@@ -109,7 +109,7 @@ describe('IndexedSet', () => {
   describe('get', () => {
     it('returns the element at the specified index', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect(set.get(0)).toBe('a')
       expect(set.get(1)).toBe('b')
@@ -118,7 +118,7 @@ describe('IndexedSet', () => {
 
     it('returns undefined for out-of-bounds index', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a')
+      set.insertAt(0, ['a'])
 
       expect(set.get(1)).toBeUndefined()
       expect(set.get(-1)).toBeUndefined()
@@ -133,13 +133,13 @@ describe('IndexedSet', () => {
 
     it('returns correct size after insertions', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
       expect(set.size).toBe(3)
     })
 
     it('returns correct size after deletions', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
       set.delete('b')
       expect(set.size).toBe(2)
     })
@@ -148,7 +148,7 @@ describe('IndexedSet', () => {
   describe('clear', () => {
     it('removes all elements', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
       set.clear()
 
       expect(set.size).toBe(0)
@@ -160,7 +160,11 @@ describe('IndexedSet', () => {
   describe('find', () => {
     it('returns the first matching element', () => {
       const set = new IndexedSet<{id: number; name: string}>()
-      set.insertAt(0, {id: 1, name: 'a'}, {id: 2, name: 'b'}, {id: 3, name: 'c'})
+      set.insertAt(0, [
+        {id: 1, name: 'a'},
+        {id: 2, name: 'b'},
+        {id: 3, name: 'c'},
+      ])
 
       const found = set.find(el => el.id === 2)
       expect(found).toEqual({id: 2, name: 'b'})
@@ -168,7 +172,7 @@ describe('IndexedSet', () => {
 
     it('returns undefined when no match', () => {
       const set = new IndexedSet<{id: number}>()
-      set.insertAt(0, {id: 1}, {id: 2})
+      set.insertAt(0, [{id: 1}, {id: 2}])
 
       expect(set.find(el => el.id === 99)).toBeUndefined()
     })
@@ -177,7 +181,7 @@ describe('IndexedSet', () => {
   describe('[Symbol.iterator]', () => {
     it('allows iteration with for...of', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       const result: string[] = []
       for (const item of set) {
@@ -189,14 +193,14 @@ describe('IndexedSet', () => {
 
     it('allows spread operator', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect([...set]).toEqual(['a', 'b', 'c'])
     })
 
     it('allows Array.from', () => {
       const set = new IndexedSet<string>()
-      set.insertAt(0, 'a', 'b', 'c')
+      set.insertAt(0, ['a', 'b', 'c'])
 
       expect(Array.from(set)).toEqual(['a', 'b', 'c'])
     })
@@ -209,7 +213,7 @@ describe('IndexedSet', () => {
       const div2 = document.createElement('div')
       const div3 = document.createElement('div')
 
-      set.insertAt(0, div1, div2, div3)
+      set.insertAt(0, [div1, div2, div3])
 
       expect(set.has(div1)).toBe(true)
       expect(set.has(div2)).toBe(true)
@@ -220,5 +224,74 @@ describe('IndexedSet', () => {
       expect(set.has(div2)).toBe(false)
       expect(set.size).toBe(2)
     })
+  })
+})
+
+describe('large dataset performance', () => {
+  it('handles inserting 45,000 elements', () => {
+    const set = new IndexedSet<number>()
+    const elements = Array.from({length: 45000}, (_, i) => i)
+
+    set.insertAt(0, elements)
+
+    expect(set.size).toBe(45000)
+    expect(set.get(0)).toBe(0)
+    expect(set.get(44999)).toBe(44999)
+    expect(set.has(22500)).toBe(true)
+    expect(set.indexOf(22500)).toBe(22500)
+  })
+
+  it('handles inserting 45,000 elements at middle index', () => {
+    const set = new IndexedSet<number>()
+    set.insertAt(0, [0, 1, 2])
+
+    const elements = Array.from({length: 45000}, (_, i) => i + 100)
+    set.insertAt(1, elements) // Insert in middle
+
+    expect(set.size).toBe(45003)
+    expect(set.get(0)).toBe(0)
+    expect(set.get(1)).toBe(100) // First inserted element
+    expect(set.get(45001)).toBe(1) // Shifted original element
+    expect(set.get(45002)).toBe(2) // Shifted original element
+  })
+
+  it('handles inserting 45,000 elements at the beginning', () => {
+    const set = new IndexedSet<number>()
+    set.insertAt(0, [-1, -2, -3])
+
+    const elements = Array.from({length: 45000}, (_, i) => i)
+    set.insertAt(0, elements) // Prepend
+
+    expect(set.size).toBe(45003)
+    expect(set.get(0)).toBe(0)
+    expect(set.get(44999)).toBe(44999)
+    expect(set.get(45000)).toBe(-1) // Original elements shifted
+    expect(set.indexOf(-1)).toBe(45000)
+  })
+
+  it('deduplicates within a large array', () => {
+    const set = new IndexedSet<number>()
+    // Create array with duplicates: [0, 1, 2, ..., 22499, 0, 1, 2, ..., 22499]
+    const elements = Array.from({length: 45000}, (_, i) => i % 22500)
+
+    set.insertAt(0, elements)
+
+    expect(set.size).toBe(22500) // Should deduplicate
+    expect(set.has(0)).toBe(true)
+    expect(set.has(22499)).toBe(true)
+  })
+
+  it('filters out existing elements when inserting large array', () => {
+    const set = new IndexedSet<number>()
+    set.insertAt(
+      0,
+      Array.from({length: 1000}, (_, i) => i),
+    )
+
+    // Try to insert 45k elements, 1000 of which already exist
+    const newElements = Array.from({length: 45000}, (_, i) => i)
+    set.insertAt(1000, newElements)
+
+    expect(set.size).toBe(45000) // 1000 original + 44000 new
   })
 })

--- a/src/focus-zone.ts
+++ b/src/focus-zone.ts
@@ -483,7 +483,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
     // Insert all elements atomically.
     const insertionIndex = findInsertionIndex(filteredElements)
-    focusableElements.insertAt(insertionIndex, ...filteredElements)
+    focusableElements.insertAt(insertionIndex, filteredElements)
     for (const element of filteredElements) {
       // Set tabindex="-1" on all tabbable elements, but save the original
       // value in case we need to disable the behavior
@@ -514,7 +514,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
   function reinitializeWithFreshElements() {
     const freshElements = [...iterateFocusableElements(container, iterateFocusableElementsOptions)]
     focusableElements.clear()
-    focusableElements.insertAt(0, ...freshElements)
+    focusableElements.insertAt(0, freshElements)
     for (const element of freshElements) {
       if (!savedTabIndex.has(element)) {
         savedTabIndex.set(element, element.getAttribute('tabindex'))

--- a/src/utils/indexed-set.ts
+++ b/src/utils/indexed-set.ts
@@ -1,38 +1,135 @@
 /**
- * A data structure that maintains both an ordered array and a Set for O(1) membership checks.
- * Use this when you need both ordered iteration/index access AND fast membership tests.
+ * A data structure that maintains both an ordered array and a Set for O(1) membership checks,
+ * plus a Map for O(1) index lookups by element.
  *
- * PERFORMANCE: Provides O(1) `has()` checks while maintaining insertion order.
- * Trade-off: Slightly more memory (Set overhead) and must call proper methods to stay in sync.
+ * PERFORMANCE:
+ * - O(1) `has()` checks
+ * - O(1) `indexOf()` lookups
+ * - O(1) `get()` by index
+ * - O(n) insertions/deletions (unavoidable for ordered array, but optimized)
+ *
+ * Optimized for focusZone use cases:
+ * - Frequent `has()` checks (mousemove handlers)
+ * - Frequent `get(index)` access (arrow key navigation)
+ * - Batch insertions via MutationObserver
+ * - Relatively infrequent deletions
  */
 export class IndexedSet<T> {
   private _items: T[] = []
   private _itemSet = new Set<T>()
+  private _indexMap = new Map<T, number>()
 
   /**
-   * Insert elements at a specific index. If index is omitted, appends to end.
+   * Insert elements at a specific index.
+   * Accepts an array to avoid call stack overflow with large datasets.
+   * O(n) due to array operations, but optimized for batch insertions.
    */
-  insertAt(index: number, ...elements: T[]): void {
-    const newElements = elements.filter(e => !this._itemSet.has(e))
+  insertAt(index: number, elements: T[]): void {
+    // Filter without creating intermediate array for small inputs
+    let newElements: T[]
+    if (elements.length <= 100) {
+      newElements = elements.filter((e, i, arr) => !this._itemSet.has(e) && arr.indexOf(e) === i)
+    } else {
+      // For large arrays, build incrementally to avoid memory spikes
+      // Use a Set to track duplicates within the input array
+      const seen = new Set<T>()
+      newElements = []
+      for (let i = 0; i < elements.length; i++) {
+        const e = elements[i]
+        if (!this._itemSet.has(e) && !seen.has(e)) {
+          seen.add(e)
+          newElements.push(e)
+        }
+      }
+    }
     if (newElements.length === 0) return
 
-    this._items.splice(index, 0, ...newElements)
-    for (const element of newElements) {
+    // Clamp index to valid range
+    const insertIndex = Math.max(0, Math.min(index, this._items.length))
+
+    // Fast path: appending to end (common case for initial load)
+    if (insertIndex === this._items.length) {
+      for (let i = 0; i < newElements.length; i++) {
+        const element = newElements[i]
+        this._indexMap.set(element, this._items.length)
+        this._items.push(element)
+        this._itemSet.add(element)
+      }
+      return
+    }
+
+    // Fast path: prepending to start
+    if (insertIndex === 0) {
+      // Update all existing indices first
+      for (let i = 0; i < this._items.length; i++) {
+        this._indexMap.set(this._items[i], i + newElements.length)
+      }
+      // Use unshift for small arrays, splice for larger (V8 optimizes splice better for large arrays)
+      if (newElements.length <= 10 && this._items.length <= 100) {
+        for (let i = newElements.length - 1; i >= 0; i--) {
+          this._items.unshift(newElements[i])
+        }
+      } else {
+        this._items.splice(0, 0, ...(newElements.length <= 10000 ? newElements : this._chunkedInsert(0, newElements)))
+      }
+      // Add new elements to Set and Map
+      for (let i = 0; i < newElements.length; i++) {
+        this._itemSet.add(newElements[i])
+        this._indexMap.set(newElements[i], i)
+      }
+      return
+    }
+
+    // General case: middle insertion
+    // Update indices for elements that will shift
+    for (let i = this._items.length - 1; i >= insertIndex; i--) {
+      this._indexMap.set(this._items[i], i + newElements.length)
+    }
+
+    // Insert new elements - use chunked approach for very large arrays
+    if (newElements.length <= 10000) {
+      this._items.splice(insertIndex, 0, ...newElements)
+    } else {
+      this._chunkedInsert(insertIndex, newElements)
+    }
+
+    // Add new elements to Set and Map
+    for (let i = 0; i < newElements.length; i++) {
+      const element = newElements[i]
       this._itemSet.add(element)
+      this._indexMap.set(element, insertIndex + i)
     }
   }
 
   /**
+   * Insert elements in chunks to avoid call stack overflow.
+   */
+  private _chunkedInsert(index: number, elements: T[]): T[] {
+    const CHUNK_SIZE = 10000
+    for (let i = 0; i < elements.length; i += CHUNK_SIZE) {
+      const chunk = elements.slice(i, i + CHUNK_SIZE)
+      this._items.splice(index + i, 0, ...chunk)
+    }
+    return [] // Return empty to signal we handled it
+  }
+
+  /**
    * Remove an element by reference. Returns true if element was found and removed.
+   * O(n) due to array splice and index updates.
    */
   delete(element: T): boolean {
     if (!this._itemSet.has(element)) return false
 
-    const index = this._items.indexOf(element)
-    if (index >= 0) {
-      this._items.splice(index, 1)
-    }
+    const index = this._indexMap.get(element)!
+    this._items.splice(index, 1)
     this._itemSet.delete(element)
+    this._indexMap.delete(element)
+
+    // Update indices for elements that shifted
+    for (let i = index; i < this._items.length; i++) {
+      this._indexMap.set(this._items[i], i)
+    }
+
     return true
   }
 
@@ -44,16 +141,14 @@ export class IndexedSet<T> {
   }
 
   /**
-   * Get the index of an element. Returns -1 if not found.
-   * Note: This is O(n) but first does O(1) membership check to fast-fail.
+   * O(1) index lookup (improved from O(n)).
    */
   indexOf(element: T): number {
-    if (!this._itemSet.has(element)) return -1
-    return this._items.indexOf(element)
+    return this._indexMap.get(element) ?? -1
   }
 
   /**
-   * Get element at index.
+   * O(1) element access by index.
    */
   get(index: number): T | undefined {
     return this._items[index]
@@ -79,6 +174,7 @@ export class IndexedSet<T> {
   clear(): void {
     this._items = []
     this._itemSet.clear()
+    this._indexMap.clear()
   }
 
   /**


### PR DESCRIPTION
This pull request significantly refactors the `IndexedSet` data structure to improve its performance and scalability, especially for large batch insertions and frequent index-based operations. The changes also update all usages and tests to match the new API, and add comprehensive tests for large datasets.

Fixes https://github.com/github/pull-requests/issues/22438

`indexed-set.js` is failing with an `Uncaught RangeError: Maximum call stack size exceeded` error.

<img width="1384" height="406" alt="Sceenshot of Uncaught RangeError" src="https://github.com/user-attachments/assets/999d19de-ede2-4085-9c4b-f348aeadbed3" />

We are seeing that a large component with many focusable elements, using `useFocusZone`, will attempt to insert a large amount of items at an index on focusableElements here: (e.g. 43,183 elements in this example).

<img width="974" height="476" alt="screen shot of focus-zone.js failing code" src="https://github.com/user-attachments/assets/c19949c7-2ad3-445b-accf-d4698d5fdc70" />

But inside of the `focusableElements.insertAt `code we are doing a filter call on an array of 43k elements just to check if there are new elements to then determine if we add the new index or not. 

<img width="982" height="694" alt="screen shot of indexed-set.js failing code" src="https://github.com/user-attachments/assets/eb110499-96b2-4c7c-8a9e-d8237d5fb4d3" />


