### PR TITLE
Add option to prevent scrolling on select elements

### DIFF
--- a/.changeset/tall-rats-visit.md
+++ b/.changeset/tall-rats-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/behaviors": patch
+---
+
+Focus-trap: Add option to prevent scrolling when programmatically setting focus.

--- a/src/__tests__/focus-trap.test.tsx
+++ b/src/__tests__/focus-trap.test.tsx
@@ -391,3 +391,47 @@ it('Should apply sr-only styles to sentinels to prevent layout shift', () => {
 
   controller?.abort()
 })
+
+it('Should focus with {preventScroll: true} when target has data-prevent-scroll-on-focus', () => {
+  const {container} = render(
+    <div id="trapContainer" style={{height: '100px', overflow: 'auto'}}>
+      <button data-prevent-scroll-on-focus tabIndex={0}>
+        Apple
+      </button>
+      <div style={{height: '2000px'}}>Tall content</div>
+      <button tabIndex={0}>Banana</button>
+    </div>,
+  )
+
+  const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const firstButton = trapContainer.querySelector('button')!
+  const focusSpy = jest.spyOn(firstButton, 'focus')
+
+  const controller = focusTrap(trapContainer)
+
+  expect(focusSpy).toHaveBeenCalledWith({preventScroll: true})
+
+  focusSpy.mockRestore()
+  controller?.abort()
+})
+
+it('Should focus with {preventScroll: false} when target does not have data-prevent-scroll-on-focus', () => {
+  const {container} = render(
+    <div id="trapContainer" style={{height: '100px', overflow: 'auto'}}>
+      <button tabIndex={0}>Apple</button>
+      <div style={{height: '2000px'}}>Tall content</div>
+      <button tabIndex={0}>Banana</button>
+    </div>,
+  )
+
+  const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const firstButton = trapContainer.querySelector('button')!
+  const focusSpy = jest.spyOn(firstButton, 'focus')
+
+  const controller = focusTrap(trapContainer)
+
+  expect(focusSpy).toHaveBeenCalledWith({preventScroll: false})
+
+  focusSpy.mockRestore()
+  controller?.abort()
+})

--- a/src/focus-trap.ts
+++ b/src/focus-trap.ts
@@ -18,6 +18,15 @@ let activeTrap: FocusTrapMetadata | undefined = undefined
 const SR_ONLY_STYLES =
   'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0'
 
+// Opt-in: elements with `data-prevent-scroll-on-focus` are focused with
+// { preventScroll: true } so the trap doesn't scroll any scrollable ancestor
+// to bring them into view.
+function focusWithDataOpt(el: HTMLElement | null | undefined): void {
+  if (!el) return
+  const preventScroll = el.hasAttribute('data-prevent-scroll-on-focus')
+  el.focus({preventScroll})
+}
+
 interface CreateSentinelOptions {
   onFocus: () => void
 }
@@ -102,7 +111,7 @@ export function focusTrap(
   const sentinelStart = createSentinel({
     onFocus: () => {
       const lastFocusableChild = getFocusableChild(container, true)
-      lastFocusableChild?.focus()
+      focusWithDataOpt(lastFocusableChild)
     },
   })
 
@@ -110,7 +119,7 @@ export function focusTrap(
     onFocus: () => {
       // If the end sentinel was focused, move focus to the start
       const firstFocusableChild = getFocusableChild(container)
-      firstFocusableChild?.focus()
+      focusWithDataOpt(firstFocusableChild)
     },
   })
 
@@ -139,14 +148,14 @@ export function focusTrap(
         return
       } else {
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
-          lastFocusedChild.focus()
+          focusWithDataOpt(lastFocusedChild)
           return
         } else if (initialFocus && container.contains(initialFocus)) {
-          initialFocus.focus()
+          focusWithDataOpt(initialFocus)
           return
         } else {
           const firstFocusableChild = getFocusableChild(container)
-          firstFocusableChild?.focus()
+          focusWithDataOpt(firstFocusableChild)
           return
         }
       }


### PR DESCRIPTION
See https://github.com/github/primer/issues/6686 for additional context

Introduces an opt-in option for controlling scroll behavior when focusing elements within the focus trap. Specifically, elements with the `data-prevent-scroll-on-focus` attribute will be focused with `{preventScroll: true}` to avoid unwanted scrolling, while others will use `{preventScroll: false}`.

There are cases where if focus is temporarily lost, it will be set to another element in the DOM. This can cause unnecessary scrolling in cases where focus is only lost for a few milliseconds.  